### PR TITLE
Update fabric8 dependency version

### DIFF
--- a/billboard/pom.xml
+++ b/billboard/pom.xml
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>fabric8-maven-plugin</artifactId>
-            <version>3.5.40</version>
+            <version>4.0.0</version>
             <executions>
               <execution>
                 <id>fmp</id>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- plugin versions -->
-    <fabric8-maven-plugin.version>3.5.40</fabric8-maven-plugin.version>
+    <fabric8-maven-plugin.version>4.0.0</fabric8-maven-plugin.version>
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>


### PR DESCRIPTION
The existing version for fabric8 requires docker, which isn't used by
OpenShift 4.x. Upping to the 4.0.0 version of the plugin fixes this
dependency. I was able to get the application deployed without having
docker installed on my local machine.